### PR TITLE
Gather apache version, even in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   command: >
     /usr/sbin/httpd -v
   changed_when: false
+  check_mode: false
   register: httpd_version
 
 # Example for how the split function works:


### PR DESCRIPTION
Collecting the apache version doesn't make any changes, it is safe to do in check mode. Skipping this task while check mode is active will cause the following task to fail
  The task includes an option with an undefined variable. The error was: 'dict
  object' has no attribute 'stdout'

Other unrelated changes:
- append newline to end of file