### PR TITLE
Enable apache log compression

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,14 @@
   with_dict: "{{ vhosts }}"
   when: vhosts is defined
 
+- name: Enable log compression
+  ansible.builtin.lineinfile:
+    path: /etc/logrotate.d/httpd
+    state: present
+    line: "    compress"
+    insertbefore: '\s*delaycompress'
+    validate: "/usr/sbin/logrotate --debug %s"
+
 - name: Enable HTTPD service
   service:
     name: "httpd"


### PR DESCRIPTION
"delaycomprss" requires "compress"
Perhaps the compress option is expected in the main logrotate.conf file, but Red Hat fails to supply it.

JIRA: LSI-374 / Compress Apache Logs